### PR TITLE
Add Dockerfile for server-single

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+# Build stage
+FROM golang:1.22.4 AS builder
+
+WORKDIR /app
+
+COPY go.mod .
+COPY server-single/main.go .
+COPY cert.crt .
+COPY cert.key .
+
+RUN go build -o server-single main.go
+
+# Final stage
+FROM alpine:latest
+
+WORKDIR /app
+
+COPY --from=builder /app/server-single .
+COPY cert.crt .
+COPY cert.key .
+
+EXPOSE 6660
+
+CMD ["./server-single"]

--- a/README.md
+++ b/README.md
@@ -28,3 +28,13 @@ go run client-http/main.go
 ```shell
 go run client-connect/main.go
 ```
+
+## Building the Docker image
+```shell
+docker build -t example-connect-http3 .
+```
+
+## Running the Docker container
+```shell
+docker run -p 6660:6660 example-connect-http3
+```


### PR DESCRIPTION
Add a Dockerfile to create a container for the `server-single` server.

* **Dockerfile**: 
  - Use a multi-stage build with `golang:1.22.4` as the base image for the build stage.
  - Use `alpine:latest` as the base image for the final stage.
  - Copy necessary files (`server-single/main.go`, `go.mod`, `cert.crt`, `cert.key`).
  - Build the application in the build stage.
  - Copy the built application to the final stage and set the entry point to run the server on port 6660.

* **README.md**:
  - Add instructions on how to build the Docker image using `docker build -t example-connect-http3 .`.
  - Add instructions on how to run the Docker container using `docker run -p 6660:6660 example-connect-http3`.

